### PR TITLE
add ability to toggle day/night with a single command/keystroke

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     },
     "icon": "images/icon.png",
     "galleryBanner": {
-      "color": "#947500",
-      "theme": "dark"
+        "color": "#947500",
+        "theme": "dark"
     },
     "repository": {
-      "type": "git",
-      "url": "https://github.com/freetonik/vscode-dnts"
+        "type": "git",
+        "url": "https://github.com/freetonik/vscode-dnts"
     },
     "engines": {
         "vscode": "^1.16.0"
@@ -23,24 +23,32 @@
         "Other"
     ],
     "keywords": [
-      "theme", "switch", "day", "night"
+        "theme",
+        "switch",
+        "day",
+        "night"
     ],
     "license": "SEE LICENSE IN LICENSE",
     "activationEvents": [
-        "onCommand:extension.switchToNightTheme",
-        "onCommand:extension.switchToDayTheme"
+        "onCommand:dayNightThemeSwitcher.switchToNightTheme",
+        "onCommand:dayNightThemeSwitcher.switchToDayTheme",
+        "onCommand:dayNightThemeSwitcher.toggleDayNightTheme"
     ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [
-          {
-            "command": "extension.switchToNightTheme",
-            "title": "Night Theme"
-          },
-          {
-            "command": "extension.switchToDayTheme",
-            "title": "Day Theme"
-          }
+            {
+                "command": "dayNightThemeSwitcher.switchToNightTheme",
+                "title": "Night Theme"
+            },
+            {
+                "command": "dayNightThemeSwitcher.switchToDayTheme",
+                "title": "Day Theme"
+            },
+            {
+                "command": "dayNightThemeSwitcher.toggleDayNightTheme",
+                "title": "Toggle Day/Night Theme"
+            }
         ],
         "configuration": {
             "type": "object",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,16 +14,33 @@ function updateSettings() {
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.workspace.onDidChangeConfiguration(updateSettings, this);
+  let extPrefix = "dayNightThemeSwitcher";
+  let themeKey = "workbench.colorTheme";
   updateSettings();
 
-  vscode.commands.registerCommand('extension.switchToNightTheme', () => {
+  vscode.commands.registerCommand(extPrefix + '.switchToNightTheme', () => {
     console.log("to night: " + nightTheme);
-    userConfig.update("workbench.colorTheme", nightTheme, true);
+    userConfig.update(themeKey, nightTheme, true);
   });
 
-  vscode.commands.registerCommand('extension.switchToDayTheme', () => {
+  vscode.commands.registerCommand(extPrefix + '.switchToDayTheme', () => {
     console.log("to day: " + dayTheme);
-    userConfig.update("workbench.colorTheme", dayTheme, true);
+    userConfig.update(themeKey, dayTheme, true);
+  });
+
+  vscode.commands.registerCommand(extPrefix + '.toggleDayNightTheme', () => {
+    // NOTE: grab the latest setting, not what's cached above
+    let currentTheme = vscode.workspace.getConfiguration().get(themeKey);
+    console.log("Current Theme: " + currentTheme);
+    if (currentTheme === dayTheme) {
+      console.log("to night: " + nightTheme);
+      userConfig.update(themeKey, nightTheme, true);
+    } else if (currentTheme === nightTheme) {
+      console.log("to day: " + dayTheme);
+      userConfig.update(themeKey, dayTheme, true);
+    } else {
+      console.log("Toggle initiated, no theme changed");
+    }
   });
 
   context.subscriptions.push(disposable);  


### PR DESCRIPTION
- moved command namespace from `extension` to `dayNightThemeSwitcher`
- small refactor to use variables in typescript to reduce repeating
- add command to toggle day/night